### PR TITLE
add NO_DIFF env flag to suppress diff output

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -222,6 +222,9 @@ func Testdata(path, ext string, got []byte) error {
 		if os.Getenv("TESTDATA_ACCEPT") != "" || os.Getenv("TA") != "" {
 			return os.Rename(gotPath, expPath)
 		}
+		if os.Getenv("NO_DIFF") != "" {
+			ds = "diff hidden with NO_DIFF=1"
+		}
 		return fmt.Errorf("diff (rerun with $TESTDATA_ACCEPT=1 or $TA=1 to accept):\n%s", ds)
 	}
 	return os.Remove(gotPath)

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -223,7 +223,7 @@ func Testdata(path, ext string, got []byte) error {
 			return os.Rename(gotPath, expPath)
 		}
 		if os.Getenv("NO_DIFF") != "" {
-			ds = "diff hidden with NO_DIFF=1"
+			ds = "diff hidden with $NO_DIFF=1"
 		}
 		return fmt.Errorf("diff (rerun with $TESTDATA_ACCEPT=1 or $TA=1 to accept):\n%s", ds)
 	}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -223,7 +223,7 @@ func Testdata(path, ext string, got []byte) error {
 			return os.Rename(gotPath, expPath)
 		}
 		if os.Getenv("NO_DIFF") != "" || os.Getenv("ND") != "" {
-			ds = "diff hidden with $NO_DIFF=1"
+			ds = "diff hidden with $NO_DIFF=1 or $ND=1"
 		}
 		return fmt.Errorf("diff (rerun with $TESTDATA_ACCEPT=1 or $TA=1 to accept):\n%s", ds)
 	}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -222,7 +222,7 @@ func Testdata(path, ext string, got []byte) error {
 		if os.Getenv("TESTDATA_ACCEPT") != "" || os.Getenv("TA") != "" {
 			return os.Rename(gotPath, expPath)
 		}
-		if os.Getenv("NO_DIFF") != "" {
+		if os.Getenv("NO_DIFF") != "" || os.Getenv("ND") != "" {
 			ds = "diff hidden with $NO_DIFF=1"
 		}
 		return fmt.Errorf("diff (rerun with $TESTDATA_ACCEPT=1 or $TA=1 to accept):\n%s", ds)


### PR DESCRIPTION
## Summary

Adds a NO_DIFF env var for scenarios where I don't want to scroll through 1000s of lines of JSON or SVG changes.

## Details
- for example when testing changes in d2, we might run `./ci/e2ereport.sh -test-case all_shapes -v` but it could be difficult to reach the logs of the run when there are many diff lines below.
- In that case I can hide the diff lines with this env var when I am only interested in the logs