### PR TITLE
remove logs from opts

### DIFF
--- a/xmain/opts.go
+++ b/xmain/opts.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"oss.terrastruct.com/util-go/cmdlog"
 	"oss.terrastruct.com/util-go/xos"
 )
 
@@ -17,12 +16,11 @@ type Opts struct {
 	Args  []string
 	Flags *pflag.FlagSet
 	env   *xos.Env
-	log   *cmdlog.Logger
 
 	flagEnv map[string]string
 }
 
-func NewOpts(env *xos.Env, log *cmdlog.Logger, args []string) *Opts {
+func NewOpts(env *xos.Env, args []string) *Opts {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	flags.SortFlags = false
 	flags.Usage = func() {}
@@ -31,7 +29,6 @@ func NewOpts(env *xos.Env, log *cmdlog.Logger, args []string) *Opts {
 		Args:    args,
 		Flags:   flags,
 		env:     env,
-		log:     log,
 		flagEnv: make(map[string]string),
 	}
 }

--- a/xmain/xmain.go
+++ b/xmain/xmain.go
@@ -38,7 +38,7 @@ func Main(run RunFunc) {
 		Env: xos.NewEnv(os.Environ()),
 	}
 	ms.Log = cmdlog.New(ms.Env, ms.Stderr)
-	ms.Opts = NewOpts(ms.Env, ms.Log, args)
+	ms.Opts = NewOpts(ms.Env, args)
 
 	wd, err := os.Getwd()
 	if err != nil {

--- a/xmain/xmaintest.go
+++ b/xmain/xmaintest.go
@@ -77,7 +77,7 @@ func (ts *TestState) Start(tb testing.TB, ctx context.Context) {
 
 		Log:  log,
 		Env:  ts.Env,
-		Opts: NewOpts(ts.Env, log, args),
+		Opts: NewOpts(ts.Env, args),
 		PWD:  ts.PWD,
 	}
 


### PR DESCRIPTION
have no idea why `log` was even part of `opts`. Maybe we were using it for something in the past