### PR TITLE
Fix race issue

### DIFF
--- a/xhttp/serve.go
+++ b/xhttp/serve.go
@@ -65,28 +65,19 @@ func Serve(ctx context.Context, shutdownTimeout time.Duration, s *http.Server, l
 		return ctx
 	}
 
-	ss := newSafeServer(s)
-
-	serverClosed := make(chan struct{})
-	var serverError error
+	done := make(chan error, 1)
 	go func() {
-		serverError = ss.ListenAndServe(l)
-		close(serverClosed)
+		done <- s.Serve(l)
 	}()
 
 	select {
-	case <-serverClosed:
-		return serverError
+	case err := <-done:
+		return err
 	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(xcontext.WithoutCancel(ctx), shutdownTimeout)
+		ctx = xcontext.WithoutCancel(ctx)
+		ctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 		defer cancel()
-
-		err := ss.Shutdown(shutdownCtx)
-		<-serverClosed // Wait for server to exit
-		if err != nil {
-			return err
-		}
-		return serverError
+		return s.Shutdown(ctx)
 	}
 
 }

--- a/xhttp/serve.go
+++ b/xhttp/serve.go
@@ -3,9 +3,12 @@ package xhttp
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"oss.terrastruct.com/util-go/xcontext"
@@ -22,23 +25,68 @@ func NewServer(log *log.Logger, h http.Handler) *http.Server {
 	}
 }
 
+type safeServer struct {
+	*http.Server
+	running int32
+	mu      sync.Mutex
+}
+
+func newSafeServer(s *http.Server) *safeServer {
+	return &safeServer{
+		Server: s,
+	}
+}
+
+func (s *safeServer) ListenAndServe(l net.Listener) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !atomic.CompareAndSwapInt32(&s.running, 0, 1) {
+		return errors.New("server is already running")
+	}
+	defer atomic.StoreInt32(&s.running, 0)
+
+	return s.Serve(l)
+}
+
+func (s *safeServer) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if atomic.LoadInt32(&s.running) == 0 {
+		return nil
+	}
+
+	return s.Server.Shutdown(ctx)
+}
+
 func Serve(ctx context.Context, shutdownTimeout time.Duration, s *http.Server, l net.Listener) error {
 	s.BaseContext = func(net.Listener) context.Context {
 		return ctx
 	}
 
-	done := make(chan error, 1)
+	ss := newSafeServer(s)
+
+	serverClosed := make(chan struct{})
+	var serverError error
 	go func() {
-		done <- s.Serve(l)
+		serverError = ss.ListenAndServe(l)
+		close(serverClosed)
 	}()
 
 	select {
-	case err := <-done:
-		return err
+	case <-serverClosed:
+		return serverError
 	case <-ctx.Done():
-		ctx = xcontext.WithoutCancel(ctx)
-		ctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
+		shutdownCtx, cancel := context.WithTimeout(xcontext.WithoutCancel(ctx), shutdownTimeout)
 		defer cancel()
-		return s.Shutdown(ctx)
+
+		err := ss.Shutdown(shutdownCtx)
+		<-serverClosed // Wait for server to exit
+		if err != nil {
+			return err
+		}
+		return serverError
 	}
+
 }


### PR DESCRIPTION
fix: Resolve race condition in HTTP server handling

* Implement thread-safe `safeServer` to wrap http.Server
* Modify Serve function to use `safeServer` for improved concurrency
* Ensure atomic operations for server start and shutdown


This change addresses a race condition in the HTTP server handling,particularly affecting CLI tests. By introducing a `safeServer` struct with atomic operations and proper synchronization, and prevent potential data races during server startup and shutdown.

Fix for https://github.com/terrastruct/d2/issues/2087